### PR TITLE
Update PurchaseOrderAnalysisDriver.scala

### DIFF
--- a/src/main/scala/com/ttn/spark/PurchaseOrderAnalysisDriver.scala
+++ b/src/main/scala/com/ttn/spark/PurchaseOrderAnalysisDriver.scala
@@ -9,7 +9,7 @@ object PurchaseOrderAnalysisDriver {
   def main(args: Array[String]): Unit = {
     // Setup configuration and create spark context
     val conf = new SparkConf().setAppName("PO analysis").setMaster("local[*]")
-    val sc = new SparkContext(conf)
+    val sc = new SparkContext(conf)  // Try SparkSession as well.
 
     // Load the source data file into RDD
     val poDetailsFile: RDD[String] = sc.textFile("src/main/resources/purchase_orders.txt")
@@ -18,7 +18,10 @@ object PurchaseOrderAnalysisDriver {
     //Create key value pairs
     val kv = poDetailsFile.map(_.split(",")).map(v => (v(0), v(1)))
 
-    val initialSet = mutable.HashSet.empty[String]
+    /*
+    * Any particular reason for specifically taking mutable HashSet
+    */
+    val initialSet = mutable.HashSet.empty[String] // Any particular reason for specifically taking mutable HashSet 
     val addToSet = (s: mutable.HashSet[String], v: String) => s += v
     val mergePartitionSets = (p1: mutable.HashSet[String], p2: mutable.HashSet[String]) => p1 ++= p2
 


### PR DESCRIPTION
I have added a couple of comments. Use of mutable collections should be justified with a reason.
Suggestion is to use immutable collection or variables in aggregateBykey function.